### PR TITLE
amux sel: use modern gpiod api for easy axis swap via dts

### DIFF
--- a/rocknix-joypad.c
+++ b/rocknix-joypad.c
@@ -680,11 +680,6 @@ MODULE_DEVICE_TABLE(of, joypad_of_match);
 /*----------------------------------------------------------------------------*/
 static struct platform_driver joypad_driver = {
 	.probe = joypad_probe,
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 13, 0))
-	.remove_new = joypad_remove,
-#else
-	.remove = joypad_remove,
-#endif
 	.driver = {
 		.name = DRV_NAME,
 		.of_match_table = of_match_ptr(joypad_of_match),


### PR DESCRIPTION
The problem
-----------
Some devices (in my case, R36MAX) have non-standard amux mapping which needs inverted `amux-sel-a` pin to swap left/right sticks.  
The old code didn't handle gpio flags (usually `GPIO_ACTIVE_LOW` in dts) for amux pins.  

Also the only documented `of_get_` gpio function is deprecated https://docs.kernel.org/driver-api/gpio/index.html#device-tree-support  

The solution
-------------
Instead of adding `active_level` hackery to more places I migrated amux selection to the new gpiod api.  
This gives `GPIO_ACTIVE_LOW|GPIO_ACTIVE_HIGH` handling for free.

P.S.
-----------
I suppose buttons should be migrated to gpiod too (at least to use modern APIs instead of deprecated ones)