### PR TITLE
Add remove callbacks in case of unbind

### DIFF
--- a/rocknix-joypad.c
+++ b/rocknix-joypad.c
@@ -636,6 +636,20 @@ static int joypad_probe(struct platform_device *pdev)
 }
 
 /*----------------------------------------------------------------------------*/
+static int joypad_remove(struct platform_device *pdev)
+{
+	struct joypad *joypad = platform_get_drvdata(pdev);
+
+	/* Make sure we stop polling */
+	mutex_lock(&joypad->lock);
+	joypad->enable = false;
+	mutex_unlock(&joypad->lock);
+
+	dev_info(&pdev->dev, "%s : removed\n", __func__);
+	return 0;
+}
+
+/*----------------------------------------------------------------------------*/
 static const struct of_device_id joypad_of_match[] = {
 	{ .compatible = "rocknix-joypad", },
 	{},
@@ -646,6 +660,7 @@ MODULE_DEVICE_TABLE(of, joypad_of_match);
 /*----------------------------------------------------------------------------*/
 static struct platform_driver joypad_driver = {
 	.probe = joypad_probe,
+	.remove = joypad_remove,
 	.driver = {
 		.name = DRV_NAME,
 		.of_match_table = of_match_ptr(joypad_of_match),

--- a/rocknix-joypad.c
+++ b/rocknix-joypad.c
@@ -636,7 +636,7 @@ static int joypad_probe(struct platform_device *pdev)
 }
 
 /*----------------------------------------------------------------------------*/
-static int joypad_remove(struct platform_device *pdev)
+static void joypad_remove(struct platform_device *pdev)
 {
 	struct joypad *joypad = platform_get_drvdata(pdev);
 
@@ -646,7 +646,6 @@ static int joypad_remove(struct platform_device *pdev)
 	mutex_unlock(&joypad->lock);
 
 	dev_info(&pdev->dev, "%s : removed\n", __func__);
-	return 0;
 }
 
 /*----------------------------------------------------------------------------*/

--- a/rocknix-singleadc-joypad.c
+++ b/rocknix-singleadc-joypad.c
@@ -1458,7 +1458,7 @@ static int joypad_probe(struct platform_device *pdev)
 }
 
 /*----------------------------------------------------------------------------*/
-static int joypad_remove(struct platform_device *pdev)
+static void joypad_remove(struct platform_device *pdev)
 {
 	struct joypad *joypad = platform_get_drvdata(pdev);
 
@@ -1480,7 +1480,6 @@ static int joypad_remove(struct platform_device *pdev)
 	}
 
 	dev_info(&pdev->dev, "%s : removed\n", __func__);
-	return 0;
 }
 
 /*----------------------------------------------------------------------------*/


### PR DESCRIPTION
Currently, if the singleadc driver ever gets unbound, it causes a kernel panic due to attempting to access memory that has been freed by devm. This PR adds a remove callback to clean up any dangling pointers in singleadc, and additionally adds a minor remove callback to quadadc to prevent inflight polling from causing any unexpected issues, mostly for consistency though.