### PR TITLE
imports: add namespace import for IIO_CONSUMER

### DIFF
--- a/rocknix-joypad.c
+++ b/rocknix-joypad.c
@@ -650,5 +650,6 @@ MODULE_DESCRIPTION("ROCKNIX joypad driver");
 MODULE_LICENSE("GPL");
 MODULE_ALIAS("platform:" DRV_NAME);
 MODULE_INFO(intree, "Y");
+MODULE_IMPORT_NS("IIO_CONSUMER");
 
 /*----------------------------------------------------------------------------*/

--- a/rocknix-singleadc-joypad.c
+++ b/rocknix-singleadc-joypad.c
@@ -1455,5 +1455,6 @@ MODULE_DESCRIPTION("ROCKNIX singleadc joypad driver");
 MODULE_LICENSE("GPL");
 MODULE_ALIAS("platform:" DRV_NAME);
 MODULE_INFO(intree, "Y");
+MODULE_IMPORT_NS("IIO_CONSUMER");
 
 /*----------------------------------------------------------------------------*/


### PR DESCRIPTION
This is needed for compilation on 7.3, but will work on older kernels as well.